### PR TITLE
CMakeLists.txt: Drop workaround for missing libexec dir on Debian. De…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,6 @@ option (enable_lcov "Generate lcov code coverage reports." ON)
 ##  GNU standard installation directories
 ## 
 include (GNUInstallDirs)
-if (EXISTS "/etc/debian_version") # Workaround for libexecdir on debian
-  set (CMAKE_INSTALL_LIBEXECDIR "${CMAKE_INSTALL_LIBDIR}")
-  set (CMAKE_INSTALL_FULL_LIBEXECDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
-endif ()
 set (CMAKE_INSTALL_PKGLIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
 set (CMAKE_INSTALL_FULL_PKGLIBEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
 


### PR DESCRIPTION
…bian moved forward and now supports FHS 3.0 (since Debian Policy 4.1.5).