### PR TITLE
Start indicator in systemd when ayatana-indicators.target is started

### DIFF
--- a/data/ayatana-indicator-session.service.in
+++ b/data/ayatana-indicator-session.service.in
@@ -1,8 +1,11 @@
 [Unit]
 Description=Ayatana Indicator Session Service
 PartOf=graphical-session.target
-After=ayatana-indicators-pre.target
+After=ayatana-indicators.target
 
 [Service]
 ExecStart=@pkglibexecdir@/ayatana-indicator-session-service
 Restart=on-failure
+
+[Install]
+WantedBy=ayatana-indicators.target

--- a/debian/ayatana-indicator-session.links
+++ b/debian/ayatana-indicator-session.links
@@ -1,0 +1,2 @@
+# Because dh-systemd does not yet support user units, we manually make the WantedBy link
+/usr/lib/systemd/user/ayatana-indicator-session.service /usr/lib/systemd/user/ayatana-indicators.target.wants/ayatana-indicator-session.service

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 
 %:
-	dh $@
+	dh $@ --with systemd
 
 override_dh_install:
 	find debian/ayatana-indicator-session/usr/lib -name *.la -delete


### PR DESCRIPTION
This starts the indicator with the ayatana-indicators.target

Patch from:
https://bazaar.launchpad.net/~mterry/indicator-session/systemd-lifecycle/diff/489

Depends on AyatanaIndicators/libayatana-indicator#7