### PR TITLE
Skip copying existing gschema files in tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ include_directories (${CMAKE_CURRENT_BINARY_DIR} ${SERVICE_INCLUDE_DIRS})
 
 # backendmock
 add_library (backendmock STATIC
-             backend-mock-actions.c 
+             backend-mock-actions.c
              backend-mock-actions.h
              backend-mock.c
              backend-mock.h

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,8 +17,8 @@ add_custom_command (OUTPUT gschemas.compiled
                             ${CMAKE_SOURCE_DIR}/tests/org.ayatana.indicator.session.backendmock.gschema.xml
                             ${CMAKE_SOURCE_DIR}/tests/org.gnome.desktop.lockdown.gschema.xml
                             ${CMAKE_SOURCE_DIR}/tests/org.gnome.settings-daemon.plugins.media-keys.gschema.xml
-                    COMMAND cp -f ${CMAKE_BINARY_DIR}/data/*gschema.xml ${SCHEMA_DIR}
-                    COMMAND cp -f ${CMAKE_SOURCE_DIR}/tests/*gschema.xml ${SCHEMA_DIR}
+                    COMMAND cp -n ${CMAKE_BINARY_DIR}/data/*gschema.xml ${SCHEMA_DIR}
+                    COMMAND cp -n ${CMAKE_SOURCE_DIR}/tests/*gschema.xml ${SCHEMA_DIR}
                     COMMAND ${COMPILE_SCHEMA_EXECUTABLE} ${SCHEMA_DIR})
 
 # DBus Activation


### PR DESCRIPTION
fixes #17 

```
cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_INSTALL_LIBEXECDIR=lib -Denable_tests=ON
make
```
I need this fix for the above on Manjaro, otherwise #17 happens.