### PR TITLE
Move common parts over to libayatana-common and clean up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,16 +24,10 @@ set (CMAKE_INSTALL_FULL_PKGLIBEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/${CMAKE_
 find_package (PkgConfig REQUIRED)
 include (FindPkgConfig)
 pkg_check_modules (SERVICE REQUIRED
+                   libayatana-common
                    glib-2.0>=2.36
                    gio-unix-2.0>=2.36)
 include_directories (${SERVICE_INCLUDE_DIRS})
-
-set(URL_DISPATCHER_1_REQUIRED_VERSION 1)
-pkg_check_modules(
-  URLDISPATCHER
-  url-dispatcher-1>=${URL_DISPATCHER_1_REQUIRED_VERSION}
-)
-include_directories(${URLDISPATCHER_INCLUDE_DIRS})
 
 set (CC_WARNING_ARGS " -Wall -pedantic -Wextra -Wno-missing-field-initializers")
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Build-Depends: cmake,
                intltool,
                libglib2.0-dev (>= 2.36),
                libgtest-dev,
-               liburl-dispatcher1-dev | hello,
                systemd [linux-any],
 Standards-Version: 4.1.1
 Homepage: https://github.com/AyatanaIndicators/ayatana-indicator-session

--- a/src/service.c
+++ b/src/service.c
@@ -24,7 +24,7 @@
 #include "recoverable-problem.h"
 #include "service.h"
 
-#include "utils.h"
+#include <ayatana/common/utils.h>
 
 #define BUS_NAME "org.ayatana.indicator.session"
 #define BUS_PATH "/org/ayatana/indicator/session"

--- a/src/utils.c
+++ b/src/utils.c
@@ -16,51 +16,6 @@
 
 #include "utils.h"
 
-static  gboolean
-is_xdg_current_desktop (const gchar* desktop)
-{
-  const gchar *xdg_current_desktop;
-  gchar **desktop_names;
-  int i;
-
-  xdg_current_desktop = g_getenv ("XDG_CURRENT_DESKTOP");
-  if (xdg_current_desktop != NULL) {
-    desktop_names = g_strsplit (xdg_current_desktop, ":", 0);
-    for (i = 0; desktop_names[i]; ++i) {
-      if (!g_strcmp0 (desktop_names[i], desktop)) {
-        g_strfreev (desktop_names);
-        return TRUE;
-      }
-    }
-    g_strfreev (desktop_names);
-  }
-  return FALSE;
-}
-
-gboolean
-is_gnome ()
-{
-  return is_xdg_current_desktop(DESKTOP_GNOME);
-}
-
-gboolean
-is_unity ()
-{
-  return is_xdg_current_desktop(DESKTOP_UNITY);
-}
-
-gboolean
-is_mate ()
-{
-  return is_xdg_current_desktop(DESKTOP_MATE);
-}
-
-gboolean
-is_xfce ()
-{
-  return is_xdg_current_desktop(DESKTOP_XFCE);
-}
-
 GHashTable*
 get_os_release (void)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,20 +20,6 @@
 #include <glib.h>
 #include <string.h>
 
-
-/* XDG_CURRENT_DESKTOP environment variable values
- * as set by well-known desktop environments
- */
-#define DESKTOP_UNITY  "Unity"
-#define DESKTOP_MATE   "MATE"
-#define DESKTOP_GNOME  "GNOME"
-#define DESKTOP_XFCE   "XFCE"
-
-gboolean is_unity();
-gboolean is_gnome();
-gboolean is_mate();
-gboolean is_xfce();
-
 const char* get_distro_name();
 const char* get_distro_url();
 const char* get_distro_bts_url();


### PR DESCRIPTION
This moves some common functions over to libayatana-common, this also
removes the direct need for any ayatana indicators to depend on
url-dispatcher as this will be handeled by libayatana-common.

This also cleans up a pretty messy code and removes many duplicates.