### PR TITLE
Travis CI: Obtain libayatana-common from upstream Git (not from distr…

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -96,6 +96,16 @@ variables:
     -enable-checker alpha.core.FixedAddr
     -enable-checker security.insecureAPI.strcpy"'
 
+before_scripts:
+  - cd ${START_DIR}
+  - if [ ! -d libayatana-common-build ]; then
+  -     git clone --depth 1  https://github.com/AyatanaIndicators/libayatana-common.git libayatana-common-build
+  - fi
+  - cd libayatana-common-build
+  - cmake . -DCMAKE_INSTALL_PREFIX=/usr
+  - make
+  - make install
+
 build_scripts:
   - if [ ${DISTRO_NAME} == "debian" ];then
   -     export CFLAGS+=" -Wsign-compare -Wunused-parameter"


### PR DESCRIPTION
…o archives).

 The libayatana-common shared library is too new to be available in the
 distros we run CI builds against and also possibly contains features in
 Git we need for testing which haven't see a release, yet.