### PR TITLE
data/org.ayatana.indicator.session: Add phone section

### DIFF
--- a/data/org.ayatana.indicator.session
+++ b/data/org.ayatana.indicator.session
@@ -3,6 +3,9 @@ Name=ayatana-indicator-session
 ObjectPath=/org/ayatana/indicator/session
 Position=10
 
+[phone]
+ObjectPath=/org/ayatana/indicator/session/desktop
+
 [desktop]
 ObjectPath=/org/ayatana/indicator/session/desktop
 


### PR DESCRIPTION
Without this Lomiri won't display the indicator.

We are currently using the Desktop profile in Phone mode also, since it appears that no alterations are needed. If this changes in the future, I will add a new Phone profile in the service source code and make any tweaks Lomiri people may request.