### PR TITLE
UnitySession -> LomiriSession: Re-rename related changes that we erroneously hid away as Ayatana DesktopSession.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -42,8 +42,8 @@ Files: src/actions.c
  tests/backend-dbus/mock-screen-saver.h
  tests/backend-dbus/mock-session-manager.cc
  tests/backend-dbus/mock-session-manager.h
- tests/backend-dbus/mock-unity-session.cc
- tests/backend-dbus/mock-unity-session.h
+ tests/backend-dbus/mock-lomiri-session.cc
+ tests/backend-dbus/mock-lomiri-session.h
  tests/backend-dbus/mock-user.cc
  tests/backend-dbus/mock-user.h
  tests/backend-dbus/mock-webcredentials.cc
@@ -88,7 +88,7 @@ Files: CMakeLists.txt
  po/POTFILES.in
  src/CMakeLists.txt
  src/backend-dbus/CMakeLists.txt
- src/backend-dbus/org.ayatana.Desktop.Session.xml
+ src/backend-dbus/com.lomiri.Shell.Session.xml
  src/backend-dbus/org.ayatana.indicators.webcredentials.xml
  src/backend-dbus/org.freedesktop.Accounts.User.xml
  src/backend-dbus/org.freedesktop.Accounts.xml

--- a/debian/copyright.in
+++ b/debian/copyright.in
@@ -100,7 +100,7 @@ Files: CMakeLists.txt
  debian/watch
  po/CMakeLists.txt
  src/CMakeLists.txt
- src/backend-dbus/org.ayatana.Desktop.Session.xml
+ src/backend-dbus/com.lomiri.Shell.Session.xml
  src/backend-dbus/org.ayatana.indicators.webcredentials.xml
  src/backend-dbus/org.freedesktop.Accounts.User.xml
  src/backend-dbus/org.freedesktop.Accounts.xml

--- a/src/backend-dbus/CMakeLists.txt
+++ b/src/backend-dbus/CMakeLists.txt
@@ -43,9 +43,10 @@ add_gdbus_codegen (BACKEND_GENERATED_SOURCES dbus-end-session-dialog
                    org.gnome.SessionManager
                    ${CMAKE_CURRENT_SOURCE_DIR}/org.gnome.SessionManager.EndSessionDialog.xml)
 
-add_gdbus_codegen (BACKEND_GENERATED_SOURCES desktop-session
-                   org.ayatana
-                   ${CMAKE_CURRENT_SOURCE_DIR}/org.ayatana.Desktop.Session.xml)
+add_gdbus_codegen_with_namespace (BACKEND_GENERATED_SOURCES lomiri-session
+                                  com.lomiri
+                                  Lomiri
+                                  ${CMAKE_CURRENT_SOURCE_DIR}/com.lomiri.Shell.Session.xml)
 
 set (SOURCES actions.c guest.c users.c backend-dbus.c utils.c)
 

--- a/src/backend-dbus/com.lomiri.Shell.Session.xml
+++ b/src/backend-dbus/com.lomiri.Shell.Session.xml
@@ -2,7 +2,7 @@
 "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
-  <interface name="org.ayatana.Desktop.Session">
+  <interface name="com.lomiri.Shell.Session">
     <method name="Lock" />
     <method name="PromptLock" />
     <method name="RequestLogout" />

--- a/tests/backend-dbus/CMakeLists.txt
+++ b/tests/backend-dbus/CMakeLists.txt
@@ -14,8 +14,8 @@ add_library (desktopmock STATIC
              mock-object.h
              mock-screen-saver.cc
              mock-screen-saver.h
-             mock-unity-session.cc
-             mock-unity-session.h
+             mock-lomiri-session.cc
+             mock-lomiri-session.h
              mock-session-manager.cc
              mock-session-manager.h
              mock-user.cc

--- a/tests/backend-dbus/gtest-mock-dbus-fixture.h
+++ b/tests/backend-dbus/gtest-mock-dbus-fixture.h
@@ -25,7 +25,7 @@
 #include "mock-display-manager-seat.h"
 #include "mock-end-session-dialog.h"
 #include "mock-screen-saver.h"
-#include "mock-unity-session.h"
+#include "mock-lomiri-session.h"
 #include "mock-session-manager.h"
 #include "mock-user.h"
 #include "mock-webcredentials.h"

--- a/tests/backend-dbus/mock-end-session-dialog.cc
+++ b/tests/backend-dbus/mock-end-session-dialog.cc
@@ -39,7 +39,7 @@ MockEndSessionDialog :: handle_open (EndSessionDialog      * object,
 
 namespace
 {
-  const char * const MY_NAME = "org.ayatana.Desktop";
+  const char * const MY_NAME = "com.lomiri.Shell";
   const char * const MY_PATH = "/org/gnome/SessionManager/EndSessionDialog";
 }
 

--- a/tests/backend-dbus/mock-lomiri-session.cc
+++ b/tests/backend-dbus/mock-lomiri-session.cc
@@ -17,36 +17,36 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "mock-unity-session.h"
+#include "mock-lomiri-session.h"
 
 
 gboolean
-MockUnitySession :: handle_lock (DesktopSession          * us,
+MockLomiriSession :: handle_lock (LomiriShellSession          * us,
                                  GDBusMethodInvocation * inv,
                                  gpointer                gself)
 {
-  static_cast<MockUnitySession*>(gself)->my_last_action = Lock;
-  desktop_session_complete_lock (us, inv);
+  static_cast<MockLomiriSession*>(gself)->my_last_action = Lock;
+  lomiri_shell_session_complete_lock (us, inv);
   return true;
 }
 
 gboolean
-MockUnitySession :: handle_prompt_lock (DesktopSession          * us,
+MockLomiriSession :: handle_prompt_lock (LomiriShellSession          * us,
                                         GDBusMethodInvocation * inv,
                                         gpointer                gself)
 {
-  static_cast<MockUnitySession*>(gself)->my_last_action = PromptLock;
-  desktop_session_complete_prompt_lock (us, inv);
+  static_cast<MockLomiriSession*>(gself)->my_last_action = PromptLock;
+  lomiri_shell_session_complete_prompt_lock (us, inv);
   return true;
 }
 
 gboolean
-MockUnitySession :: handle_request_logout (DesktopSession          * us,
+MockLomiriSession :: handle_request_logout (LomiriShellSession          * us,
                                            GDBusMethodInvocation * inv,
                                            gpointer                gself)
 {
-  static_cast<MockUnitySession*>(gself)->my_last_action = RequestLogout;
-  desktop_session_complete_request_logout (us, inv);
+  static_cast<MockLomiriSession*>(gself)->my_last_action = RequestLogout;
+  lomiri_shell_session_complete_request_logout (us, inv);
   return true;
 }
 
@@ -56,15 +56,15 @@ MockUnitySession :: handle_request_logout (DesktopSession          * us,
 
 namespace
 {
-  const char * const UNITY_SESSION_NAME = "org.ayatana.Desktop";
-  const char * const UNITY_SESSION_PATH = "/org/ayatana/Desktop/Session";
+  const char * const LOMIRI_SESSION_NAME = "com.lomiri.Shell";
+  const char * const LOMIRI_SESSION_PATH = "/com/lomiri/Shell/Session";
 
 }
 
-MockUnitySession :: MockUnitySession (GMainLoop       * loop,
+MockLomiriSession :: MockLomiriSession (GMainLoop       * loop,
                                       GDBusConnection * bus_connection):
-  MockObject (loop, bus_connection, UNITY_SESSION_NAME, UNITY_SESSION_PATH),
-  my_skeleton (desktop_session_skeleton_new ()),
+  MockObject (loop, bus_connection, LOMIRI_SESSION_NAME, LOMIRI_SESSION_PATH),
+  my_skeleton (lomiri_shell_session_skeleton_new ()),
   my_last_action (None)
 {
   g_signal_connect (my_skeleton, "handle-lock",
@@ -77,7 +77,7 @@ MockUnitySession :: MockUnitySession (GMainLoop       * loop,
   set_skeleton (G_DBUS_INTERFACE_SKELETON(my_skeleton));
 }
 
-MockUnitySession :: ~MockUnitySession ()
+MockLomiriSession :: ~MockLomiriSession ()
 {
   g_clear_object (&my_skeleton);
 }

--- a/tests/backend-dbus/mock-lomiri-session.h
+++ b/tests/backend-dbus/mock-lomiri-session.h
@@ -17,19 +17,19 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MOCK_UNITY_SESSION_H
-#define MOCK_UNITY_SESSION_H
+#ifndef MOCK_LOMIRI_SESSION_H
+#define MOCK_LOMIRI_SESSION_H
 
 #include "mock-object.h" // parent class
-#include "backend-dbus/desktop-session.h" // Desktop Session
+#include "backend-dbus/lomiri-session.h" // Lomiri Session
 
-class MockUnitySession: public MockObject
+class MockLomiriSession: public MockObject
 {
   public:
 
-    MockUnitySession (GMainLoop       * loop,
+    MockLomiriSession (GMainLoop       * loop,
                       GDBusConnection * bus_connection);
-    virtual ~MockUnitySession ();
+    virtual ~MockLomiriSession ();
 
   public:
 
@@ -39,16 +39,16 @@ class MockUnitySession: public MockObject
 
   private:
 
-    DesktopSession * my_skeleton;
+    LomiriShellSession * my_skeleton;
     Action my_last_action;
 
-    static gboolean handle_lock (DesktopSession *,
+    static gboolean handle_lock (LomiriShellSession *,
                                  GDBusMethodInvocation *,
                                  gpointer);
-    static gboolean handle_prompt_lock (DesktopSession *,
+    static gboolean handle_prompt_lock (LomiriShellSession *,
                                         GDBusMethodInvocation *,
                                         gpointer);
-    static gboolean handle_request_logout (DesktopSession *,
+    static gboolean handle_request_logout (LomiriShellSession *,
                                            GDBusMethodInvocation *,
                                            gpointer);
 

--- a/tests/backend-dbus/test-actions.cc
+++ b/tests/backend-dbus/test-actions.cc
@@ -263,10 +263,10 @@ TEST_F (Actions, PowerOff)
   g_settings_reset (indicator_settings, SUPPRESS_KEY);
 }
 
-TEST_F (Actions, LogoutUnity)
+TEST_F (Actions, LogoutLomiri)
 {
-  MockUnitySession desktop_session(loop, conn);
-  ASSERT_EQ (MockUnitySession::None, desktop_session.last_action());
+  MockLomiriSession lomiri_session(loop, conn);
+  ASSERT_EQ (MockLomiriSession::None, lomiri_session.last_action());
   wait_msec();
 
   // confirm that user is prompted
@@ -276,7 +276,7 @@ TEST_F (Actions, LogoutUnity)
   ASSERT_TRUE (end_session_dialog->is_open());
   end_session_dialog->cancel();
   wait_msec (50);
-  ASSERT_EQ (MockUnitySession::None, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::None, lomiri_session.last_action());
 
   // confirm that user is prompted
   // and that logout is called when user confirms the logout dialog
@@ -285,19 +285,19 @@ TEST_F (Actions, LogoutUnity)
   ASSERT_TRUE (end_session_dialog->is_open ());
   end_session_dialog->confirm_logout ();
   wait_msec (100);
-  ASSERT_EQ (MockUnitySession::RequestLogout, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::RequestLogout, lomiri_session.last_action());
 
   // confirm that we try to call SessionManager::LogoutQuet
   // when prompts are disabled
   login1_manager->clear_last_action ();
-  desktop_session.clear_last_action ();
+  lomiri_session.clear_last_action ();
   ASSERT_EQ ("", login1_manager->last_action());
-  ASSERT_EQ (MockUnitySession::None, desktop_session.last_action ());
+  ASSERT_EQ (MockLomiriSession::None, lomiri_session.last_action ());
   g_settings_set_boolean (indicator_settings, SUPPRESS_KEY, TRUE);
   wait_msec (50);
   indicator_session_actions_logout (actions);
   wait_msec (50);
-  ASSERT_EQ (MockUnitySession::RequestLogout, desktop_session.last_action ());
+  ASSERT_EQ (MockLomiriSession::RequestLogout, lomiri_session.last_action ());
   g_settings_reset (indicator_settings, SUPPRESS_KEY);
 }
 
@@ -356,29 +356,29 @@ TEST_F (Actions, Hibernate)
 
 TEST_F (Actions, SwitchToScreensaver)
 {
-  MockUnitySession desktop_session(loop, conn);
+  MockLomiriSession lomiri_session(loop, conn);
 
-  ASSERT_EQ (MockUnitySession::None, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::None, lomiri_session.last_action());
   indicator_session_actions_switch_to_screensaver (actions);
   wait_msec (50);
-  ASSERT_EQ (MockUnitySession::Lock, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::Lock, lomiri_session.last_action());
 }
 
 TEST_F (Actions, SwitchToGreeter)
 {
-  MockUnitySession desktop_session(loop, conn);
+  MockLomiriSession lomiri_session(loop, conn);
 
   ASSERT_NE (MockDisplayManagerSeat::GREETER, dm_seat->last_action());
-  ASSERT_EQ (MockUnitySession::None, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::None, lomiri_session.last_action());
   indicator_session_actions_switch_to_greeter (actions);
   wait_msec (50);
-  ASSERT_EQ (MockUnitySession::PromptLock, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::PromptLock, lomiri_session.last_action());
   ASSERT_EQ (MockDisplayManagerSeat::GREETER, dm_seat->last_action());
 }
 
 TEST_F (Actions, SwitchToGuest)
 {
-  MockUnitySession desktop_session(loop, conn);
+  MockLomiriSession lomiri_session(loop, conn);
 
   // allow guests
   dm_seat->set_guest_allowed (true);
@@ -394,12 +394,12 @@ TEST_F (Actions, SwitchToGuest)
   wait_for_signal (login1_seat->skeleton(), "notify::active-session");
   ASSERT_EQ (guest_session_tag, login1_seat->active_session());
   wait_msec (50);
-  ASSERT_EQ (MockUnitySession::PromptLock, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::PromptLock, lomiri_session.last_action());
 }
 
 TEST_F (Actions, SwitchToUsername)
 {
-  MockUnitySession desktop_session(loop, conn);
+  MockLomiriSession lomiri_session(loop, conn);
   const char * const dr1_username = "whartnell";
   const char * const dr2_username = "ptroughton";
   MockUser * dr1_user;
@@ -417,7 +417,7 @@ TEST_F (Actions, SwitchToUsername)
   wait_for_signal (login1_seat->skeleton(), "notify::active-session");
   ASSERT_EQ (dr1_session, login1_seat->active_session());
   wait_msec (50);
-  ASSERT_EQ (MockUnitySession::PromptLock, desktop_session.last_action());
+  ASSERT_EQ (MockLomiriSession::PromptLock, lomiri_session.last_action());
 
   indicator_session_actions_switch_to_username (actions, dr2_username);
   wait_for_signal (login1_seat->skeleton(), "notify::active-session");


### PR DESCRIPTION
 This brings full Lomiri integration finally. Until now, the session
 indicator somehow seemed to work, but in some odd ways. On the phone,
 the session indicator would fallback to direct systemd interaction while
 on Lomiri in Debian, it would fallback to Zenity dialogs (most of all
 because Zenity got installed by some other package as a dependency).

 With this massive renaming change, ayatana-indicator-session should now
 smoothly interact with the com.lomiri.Shell.Session DBus interface and
 also with the mimicked GNOME SessionManager End-Session-Dialog
 interface.

 As a downside, this change nearly fully removes Unity7 support which
 would need to be brought back +/- as a full duplicate of what we do for
 Lomiri. But as noone has dared integrating Ayatana Indicator Session
 with Unity7, so far, we should be able to live with that for now.

 Fixes https://github.com/AyatanaIndicators/ayatana-indicator-session/issues/82