### PR TITLE
tests/backend-dbus/mock-login1-seat.cc: fix build with GCC 13

### DIFF
--- a/tests/backend-dbus/mock-login1-seat.cc
+++ b/tests/backend-dbus/mock-login1-seat.cc
@@ -17,6 +17,7 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cstdint>
 #include "mock-login1-seat.h"
 
 #include "mock-object.h"


### PR DESCRIPTION
This pull request fixes a minor issue with the `tests/backend-dbus/mock-login1-seat.cc` when building using GCC 13.

One of the standard library headers now needs to be included explicitly.