### PR TITLE
src/service.c: Initialize bLocal as true if building without RDA supp…

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1425,6 +1425,8 @@ indicator_session_service_init (IndicatorSessionService * self)
   self->priv = p;
 #if RDA_ENABLED
   self->priv->bLocal = rda_session_is_local ();
+#else
+  self->priv->bLocal = true;
 #endif /* RDA_ENABLED */
 
   /* init the backend objects */


### PR DESCRIPTION
…ort.

This assumes that the session is always local.