### PR TITLE
src/service.c: Use !rda_session_is_remote() rather than rda_session_i…

### DIFF
--- a/src/service.c
+++ b/src/service.c
@@ -1424,7 +1424,7 @@ indicator_session_service_init (IndicatorSessionService * self)
 
   self->priv = p;
 #if RDA_ENABLED
-  self->priv->bLocal = rda_session_is_local ();
+  self->priv->bLocal = !rda_session_is_remote ();
 #else
   self->priv->bLocal = true;
 #endif /* RDA_ENABLED */


### PR DESCRIPTION
…s_local().

 When using rda_session_is_local() you really get the answer you are
 asking for: the desktop session runs on a local XDG_SEAT.

 However, we'd rather like to know: is the session remote. If not let's
 treat what we are in as local.

 This popped up in build chrooted environments where XDG_SEAT is
 undefined, but still: we are definitely not in a remote session.

 Fixes: https://github.com/AyatanaIndicators/ayatana-indicator-session/issues/90

cc @z3ntu